### PR TITLE
feat(servicos): Implementa tela de listagem e gerenciamento de serviços

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,10 +33,11 @@ from src.views.gerir_pecas_view import GerirPecasViewFactory
 from src.views.cadastro_peca_view import CadastroPecaViewFactory
 from src.views.editar_peca_view import EditarPecaViewFactory
 from src.views.gerir_mecanicos_view import GerirMecanicosViewFactory
-# -> Será criado depois
 from src.views.cadastro_mecanico_view import CadastroMecanicoViewFactory
-# -> Será criado depois
 from src.views.editar_mecanico_view import EditarMecanicoViewFactory
+from src.views.gerir_servicos_view import GerirServicosViewFactory
+# from src.views.cadastro_servico_view import CadastroServicoViewFactory
+# from src.views.editar_servico_view import EditarServicoViewFactory
 
 # Importações de Serviços e Banco de Dados
 from src.services.task_queue_service import processar_fila_db
@@ -98,6 +99,7 @@ def main(page: ft.Page):
         edit_carro_route = re.match(r"/editar_carro/(\d+)", page.route)
         edit_peca_route = re.match(r"/editar_peca/(\d+)", page.route)
         edit_mecanico_route = re.match(r"/editar_mecanico/(\d+)", page.route)
+        edit_servico_route = re.match(r"/editar_servico/(\d+)", page.route)
         page.views.clear()
 
         # Mapeamento de rotas para as View Factories
@@ -154,11 +156,16 @@ def main(page: ft.Page):
             page.views.append(EditarMecanicoViewFactory(
                 page, mecanico_id=mecanico_id))
 
+        # --- NOVAS ROTAS DE SERVIÇOS ---
         elif page.route == "/gerir_servicos":
-            page.views.append(PlaceholderViewFactory(
-                page, "Gerenciar Serviços"))
+            page.views.append(GerirServicosViewFactory(page))
+        # elif page.route == "/cadastro_servico":
+            # page.views.append(CadastroServicoViewFactory(page))
+        # elif edit_servico_route:
+            # servico_id = int(edit_servico_route.group(1))
+            # page.views.append(EditarServicoViewFactory(page, servico_id=servico_id))
 
-        # --- Rotas de Serviços ---
+        # --- Rotas de Ordem de Serviços ---
         elif page.route == "/nova_os":
             page.views.append(PlaceholderViewFactory(
                 page, "Nova Ordem de Serviço"))

--- a/src/viewmodels/gerir_servicos_viewmodel.py
+++ b/src/viewmodels/gerir_servicos_viewmodel.py
@@ -1,0 +1,67 @@
+# =================================================================================
+# MÓDULO DO VIEWMODEL DE GERENCIAMENTO DE SERVIÇOS (gerir_servicos_viewmodel.py)
+# =================================================================================
+import flet as ft
+import logging
+from src.database import queries
+
+logger = logging.getLogger(__name__)
+
+class GerirServicosViewModel:
+    def __init__(self, page: ft.Page):
+        self.page = page
+        self._view: 'GerirServicosView' | None = None
+        self._servico_para_acao_id: int | None = None
+        logger.debug("GerirServicosViewModel inicializado.")
+
+    def vincular_view(self, view: 'GerirServicosView'):
+        self._view = view
+
+    def carregar_servicos_iniciais(self):
+        self.pesquisar_servico("")
+
+    def pesquisar_servico(self, termo: str):
+        if not self._view: return
+        servicos_encontrados = queries.buscar_servicos_por_termo(termo)
+        self._view.atualizar_lista_resultados(servicos_encontrados)
+
+    def editar_servico(self, servico_id: int):
+        self.page.go(f"/editar_servico/{servico_id}")
+
+    def solicitar_desativacao(self, servico_id: int, servico_nome: str):
+        self._servico_para_acao_id = servico_id
+        if self._view:
+            self._view.mostrar_dialogo_confirmacao(servico_nome, is_activating=False)
+
+    def confirmar_desativacao(self):
+        if self._servico_para_acao_id is None: return
+        try:
+            sucesso = queries.desativar_servico_por_id(self._servico_para_acao_id)
+            if self._view:
+                self._view.fechar_dialogo()
+                if sucesso:
+                    self._view.mostrar_feedback("Serviço desativado com sucesso!", True)
+                    self.carregar_servicos_iniciais()
+                else:
+                    self._view.mostrar_feedback("Erro ao desativar o serviço.", False)
+        finally:
+            self._servico_para_acao_id = None
+            
+    def solicitar_ativacao(self, servico_id: int, servico_nome: str):
+        self._servico_para_acao_id = servico_id
+        if self._view:
+            self._view.mostrar_dialogo_confirmacao(servico_nome, is_activating=True)
+
+    def confirmar_ativacao(self):
+        if self._servico_para_acao_id is None: return
+        try:
+            sucesso = queries.ativar_servico_por_id(self._servico_para_acao_id)
+            if self._view:
+                self._view.fechar_dialogo()
+                if sucesso:
+                    self._view.mostrar_feedback("Serviço reativado com sucesso!", True)
+                    self.carregar_servicos_iniciais()
+                else:
+                    self._view.mostrar_feedback("Erro ao reativar o serviço.", False)
+        finally:
+            self._servico_para_acao_id = None

--- a/src/views/gerir_servicos_view.py
+++ b/src/views/gerir_servicos_view.py
@@ -1,0 +1,139 @@
+# =================================================================================
+# MÓDULO DA VIEW DE GERENCIAMENTO DE SERVIÇOS (gerir_servicos_view.py)
+# =================================================================================
+import flet as ft
+from src.viewmodels.gerir_servicos_viewmodel import GerirServicosViewModel
+from src.models.models import Servico
+from typing import List
+from src.styles.style import AppDimensions, AppFonts
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class GerirServicosView(ft.Column):
+    def __init__(self, page: ft.Page):
+        super().__init__()
+        self.page = page
+        self.view_model = GerirServicosViewModel(page)
+        self.view_model.vincular_view(self)
+        self.on_mount = self.did_mount
+
+        self._campo_pesquisa = ft.TextField(
+            label="Pesquisar por Nome ou Descrição",
+            on_submit=lambda e: self.view_model.pesquisar_servico(
+                self._campo_pesquisa.value),
+            prefix_icon=ft.Icons.SEARCH,
+            border_radius=ft.border_radius.all(AppDimensions.BORDER_RADIUS)
+        )
+        self._resultados_pesquisa_listview = ft.ListView(
+            expand=True, spacing=10)
+        self._confirm_dialog = ft.AlertDialog(
+            modal=True, title=ft.Text("Confirmar Ação"), content=ft.Text(),
+            actions=[ft.TextButton(
+                "Cancelar", on_click=self.fechar_dialogo), ft.ElevatedButton("Confirmar")],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+
+        self.controls = [self._campo_pesquisa,
+                         ft.Divider(), self._resultados_pesquisa_listview]
+
+    def did_mount(self):
+        self.view_model.carregar_servicos_iniciais()
+
+    def atualizar_lista_resultados(self, servicos: List[Servico]):
+        self._resultados_pesquisa_listview.controls.clear()
+        if not servicos:
+            self._resultados_pesquisa_listview.controls.append(
+                ft.Text("Nenhum serviço encontrado."))
+        else:
+            for servico in servicos:
+                action_icon = (
+                    ft.IconButton(
+                        icon=ft.Icons.RESTORE, tooltip="Reativar Serviço",
+                        on_click=lambda e, s=servico: self.view_model.solicitar_ativacao(
+                            s.id, s.nome),
+                        icon_color=ft.Colors.GREEN_400,
+                    ) if not servico.ativo else ft.IconButton(
+                        icon=ft.Icons.DELETE_OUTLINE, tooltip="Desativar Serviço",
+                        on_click=lambda e, s=servico: self.view_model.solicitar_desativacao(
+                            s.id, s.nome),
+                        icon_color=ft.Colors.RED_400,
+                    )
+                )
+                list_item = ft.Container(
+                    on_click=lambda _, s=servico: self.view_model.editar_servico(
+                        s.id),
+                    border_radius=ft.border_radius.all(AppDimensions.BORDER_RADIUS), ink=True,
+                    padding=ft.padding.symmetric(vertical=8, horizontal=12),
+                    opacity=1.0 if servico.ativo else 0.5,
+                    content=ft.Row(
+                        alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                        controls=[
+                            ft.Column(
+                                expand=True, spacing=2,
+                                controls=[
+                                    ft.Text(servico.nome,
+                                            size=AppFonts.BODY_LARGE),
+                                    ft.Text(
+                                        f"Valor: R$ {servico.valor:.2f}", size=AppFonts.BODY_SMALL, color=ft.Colors.ON_SURFACE_VARIANT),
+                                ]
+                            ),
+                            ft.Row(spacing=0, controls=[
+                                   action_icon, ft.Icon(ft.Icons.CHEVRON_RIGHT)])
+                        ]
+                    )
+                )
+                self._resultados_pesquisa_listview.controls.append(list_item)
+        self.update()
+
+    def mostrar_dialogo_confirmacao(self, servico_nome: str, is_activating: bool):
+        if self._confirm_dialog not in self.page.overlay:
+            self.page.overlay.append(self._confirm_dialog)
+        if is_activating:
+            self._confirm_dialog.content.value = f"Tem certeza de que deseja reativar o serviço '{servico_nome}'?"
+            self._confirm_dialog.actions[1].text = "Sim, Reativar"
+            self._confirm_dialog.actions[1].on_click = lambda _: self.view_model.confirmar_ativacao(
+            )
+            self._confirm_dialog.actions[1].bgcolor = ft.Colors.GREEN_700
+        else:
+            self._confirm_dialog.content.value = f"Tem certeza de que deseja desativar o serviço '{servico_nome}'?"
+            self._confirm_dialog.actions[1].text = "Sim, Desativar"
+            self._confirm_dialog.actions[1].on_click = lambda _: self.view_model.confirmar_desativacao(
+            )
+            self._confirm_dialog.actions[1].bgcolor = self.page.theme.color_scheme.error
+        self._confirm_dialog.open = True
+        self.page.update()
+
+    def fechar_dialogo(self, e=None):
+        if self._confirm_dialog in self.page.overlay:
+            self._confirm_dialog.open = False
+            self.page.update()
+
+    def mostrar_feedback(self, mensagem: str, sucesso: bool):
+        self.page.snack_bar = ft.SnackBar(
+            content=ft.Text(mensagem),
+            bgcolor=self.page.theme.color_scheme.primary if sucesso else self.page.theme.color_scheme.error
+        )
+        self.page.snack_bar.open = True
+        self.page.update()
+
+
+def GerirServicosViewFactory(page: ft.Page) -> ft.View:
+    return ft.View(
+        route="/gerir_servicos",
+        appbar=ft.AppBar(title=ft.Text("Gerenciar Serviços"),
+                         center_title=True, bgcolor=page.theme.color_scheme.surface),
+        floating_action_button=ft.Row(
+            [
+                ft.FloatingActionButton(
+                    icon=ft.Icons.ARROW_BACK, tooltip="Voltar ao Dashboard", on_click=lambda _: page.go("/dashboard")),
+                ft.FloatingActionButton(
+                    icon=ft.Icons.ADD, tooltip="Cadastrar Novo Serviço", on_click=lambda _: page.go("/cadastro_servico"))
+            ],
+            alignment=ft.MainAxisAlignment.END,
+        ),
+        controls=[ft.SafeArea(content=ft.Container(content=GerirServicosView(
+            page), padding=AppDimensions.PAGE_PADDING), expand=True)],
+        padding=0
+    )


### PR DESCRIPTION
Adiciona a funcionalidade de "Read" para o CRUD de Serviços, permitindo a visualização, busca e gerenciamento de status (ativo/inativo).

- **Queries:** Implementado o conjunto completo de funções CRUD (`criar`, `buscar`, `obter`, `atualizar`, `ativar`, `desativar`) para a entidade `servicos` em `queries.py`.
- **ViewModel:** Criado `gerir_servicos_viewmodel.py` para encapsular a lógica de busca e as ações de ativação/desativação.
- **View:** Criado `gerir_servicos_view.py` para construir a interface de listagem, seguindo o padrão de design e o uso de `overlay` para diálogos.
- **Navegação:** A rota `/gerir_servicos` foi ativada no `main.py` e integrada ao botão "Serviços" do dashboard.